### PR TITLE
fix recipe yield parsing error

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import { Open_Sans, Yeseva_One } from 'next/font/google'
 import classNames from 'classnames'
 import { cookies } from 'next/headers'
-import { ErrorBoundary } from 'react-error-boundary'
 
 import { AuthContextProvider } from '@/context/AuthContext'
 
@@ -10,7 +9,6 @@ import './globals.css'
 import CookieBanner from '@/components/molecules/CookieBanner'
 import NotificationProvider from '@/context/NotificationContext'
 import GA4 from '@/components/atoms/GA4'
-import Fallback from '@/components/molecules/ErrorFallback'
 import LogRocketInit from '@/components/atoms/LogRocket'
 
 const openSans = Open_Sans({
@@ -40,18 +38,16 @@ export default async function RootLayout({ children }: {
       <GA4 />
       <body>
         <LogRocketInit />
-        <ErrorBoundary FallbackComponent={Fallback}>
-          <NotificationProvider>
-            <AuthContextProvider user={null}>
-              <div className="min-h-screen flex flex-col">
-                <div className="flex-grow flex flex-col ">
-                  {children}
-                </div>
-                {!cookies().get('cookie_consent') && <CookieBanner />}
+        <NotificationProvider>
+          <AuthContextProvider user={null}>
+            <div className="min-h-screen flex flex-col">
+              <div className="flex-grow flex flex-col ">
+                {children}
               </div>
-            </AuthContextProvider>
-          </NotificationProvider>
-        </ErrorBoundary>
+              {!cookies().get('cookie_consent') && <CookieBanner />}
+            </div>
+          </AuthContextProvider>
+        </NotificationProvider>
       </body>
     </html>
   )

--- a/src/app/recipe/View.tsx
+++ b/src/app/recipe/View.tsx
@@ -86,7 +86,7 @@ export default function Recipe({ recipe }: Props) {
     } else {
       const recipeYieldNum = Number(recipeYield)
       if (!isNaN(recipeYieldNum)) {
-        if (recipeYieldNum > 0 && !recipeYields?.find(y => y.startsWith(`${recipeYieldNum} `))) {
+        if (recipeYieldNum > 0 && !recipeYields?.find(y => (y + '').startsWith(`${recipeYieldNum} `))) {
           return `${recipeYieldNum} serving${recipeYieldNum !== 1 ? 's' : ''}`
         }
         return ''

--- a/src/components/layouts/AppLayout.tsx
+++ b/src/components/layouts/AppLayout.tsx
@@ -1,14 +1,16 @@
 'use client'
 
 import { ReactNode, useEffect } from 'react'
+import classNames from 'classnames'
+import { useRouter } from 'next/navigation'
+import { ErrorBoundary } from 'react-error-boundary'
 
 import { useAuthContext } from '@/context/AuthContext'
 
 import Header from '@/components/partials/Header'
 import Footer from '@/components/partials/Footer'
-import classNames from 'classnames'
-import RecipeError from '../molecules/RecipeError'
-import { useRouter } from 'next/navigation'
+import RecipeError from '@/components/molecules/RecipeError'
+import Fallback from '@/components/molecules/ErrorFallback'
 
 interface Props {
   fullWidth?: boolean
@@ -50,16 +52,18 @@ export default function AppLayout({
     <>
       <Header withBorder withSearch={withSearch} className={classNames(userLoading && 'invisible')} />
       <div className={classNames('grow', userLoading && 'invisible', className)}>
-        {unauthorized
-          ? <RecipeError
-            errorTitle="Unauthorized"
-            errorText="You must be logged in to access this page."
-            actionText="Take me home"
-            actionUrl="/"
-            className="max-w-xl py-8 mx-auto"
-          />
-          : renderChildren()
-        }
+        <ErrorBoundary FallbackComponent={Fallback} >
+          {unauthorized
+            ? <RecipeError
+              errorTitle="Unauthorized"
+              errorText="You must be logged in to access this page."
+              actionText="Take me home"
+              actionUrl="/"
+              className="max-w-xl py-8 mx-auto"
+            />
+            : renderChildren()
+          }
+        </ErrorBoundary>
       </div>
       <Footer className={classNames(userLoading && 'invisible')} />
     </>

--- a/src/components/molecules/ErrorFallback.tsx
+++ b/src/components/molecules/ErrorFallback.tsx
@@ -4,7 +4,7 @@ import RecipeError from './RecipeError'
 const Fallback = ({ error }: { error: Error }) => {
   return (
     <div className="max-w-xl mx-auto flex items-center min-h-screen">
-      <RecipeError type="critical" details={error} />
+      <RecipeError type="critical" details={error} actionUrl="/" actionText="Go home" />
     </div>
   )
 }

--- a/src/components/molecules/Nutrition.tsx
+++ b/src/components/molecules/Nutrition.tsx
@@ -38,6 +38,8 @@ export default function NutritionInfo({ data: _data, ingredientsList, recipeYiel
   const [showEdamam, setShowEdamam] = useState(false)
   const [error, setError] = useState(false)
 
+  const hasData = data && Object.keys(data).filter(k => k !== '@type').length
+
   const loadNutritionInfo = async () => {
     try {
       setLoading(true)
@@ -68,7 +70,7 @@ export default function NutritionInfo({ data: _data, ingredientsList, recipeYiel
 
   const note = <div className="text-xs mb-3">Note: The information shown below is {showEdamam ? 'Edamam\'s' : 'an'} estimate based on available ingredients and preparation. It should not be considered a substitute for a professional advice.</div>
 
-  if (!data && user) {
+  if (!hasData && user) {
     return (
       <div className="print:hidden">
         <h2 className="text-xl font-bold mb-2">Nutrition</h2>
@@ -99,7 +101,7 @@ export default function NutritionInfo({ data: _data, ingredientsList, recipeYiel
     )
   }
 
-  if (!data) {
+  if (!hasData) {
     return null
   }
 


### PR DESCRIPTION
- Move error boundary inside header/footer
- Fix error thrown when recipeYield in schema is a number
- Hide nutrition section if only entry in the object is `'@type': 'NutritionInformation'`